### PR TITLE
Reset threadlocal vars when finished deserializing Node

### DIFF
--- a/src/intern.rs
+++ b/src/intern.rs
@@ -43,6 +43,7 @@ impl Drop for Guard {
     fn drop(&mut self) {
         let prev = REFCOUNT.with(|refcount| refcount.replace(refcount.get() - 1));
         if prev == 1 {
+            crate::loc::thread_local_reset();
             INTERN.with(|intern| intern.borrow_mut().clear());
         }
     }

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -40,6 +40,11 @@ thread_local! {
     static LAST_LOC_LINE: Cell<usize> = Cell::new(0);
 }
 
+pub(crate) fn thread_local_reset() {
+    LAST_LOC_FILENAME.with(|last_loc_filename| *last_loc_filename.borrow_mut() = Arc::from(""));
+    LAST_LOC_LINE.with(|last_loc_line| last_loc_line.set(0));
+}
+
 enum SourceLocationField {
     SpellingLoc,
     ExpansionLoc,

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -41,7 +41,12 @@ thread_local! {
 }
 
 pub(crate) fn thread_local_reset() {
-    LAST_LOC_FILENAME.with(|last_loc_filename| *last_loc_filename.borrow_mut() = Arc::from(""));
+    LAST_LOC_FILENAME.with(|last_loc_filename| {
+        let mut last_loc_filename = last_loc_filename.borrow_mut();
+        if !last_loc_filename.is_empty() {
+            *last_loc_filename = Arc::from("");
+        }
+    });
     LAST_LOC_LINE.with(|last_loc_line| last_loc_line.set(0));
 }
 


### PR DESCRIPTION
Without this, data can bleed over from one top-level deserialization to the next, resulting in the same input being deserialized inconsistently in different ways. For example previously the assertion in the following repro fails, meaning deserializing the same input object twice produced two unequal results:

```rust
use clang_ast::SourceLocation;
use serde::Deserialize;
use serde_json::json;

type Node = clang_ast::Node<Clang>;

#[derive(Deserialize, Debug)]
struct Clang {
    loc: Option<SourceLocation>,
}

fn main() {
    let j = json!({
        "id": "0x1",
        "kind": "TranslationUnitDecl",
        "inner": [
            {
                "id": "0x2",
                "kind": "CXXUnresolvedConstructExpr",
                "loc": {
                    "offset": 1,
                    "col": 0,
                    "tokLen": 0,
                },
            },
            {
                "id": "0x3",
                "kind": "CXXUnresolvedConstructExpr",
                "loc": {
                    "offset": 1,
                    "line": 1,
                    "col": 0,
                    "tokLen": 0,
                },
            },
        ],
    });

    let first = Node::deserialize(&j).unwrap();
    let second = Node::deserialize(&j).unwrap();
    println!("{:#?}\n{:#?}", first, second);
    assert_eq!(
        first.inner[0].kind.loc.as_ref().unwrap().spelling_loc.as_ref().unwrap().line,
        second.inner[0].kind.loc.as_ref().unwrap().spelling_loc.as_ref().unwrap().line,
    );
}
```