### PR TITLE
Support Option<String> as kind field in caller's struct

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -444,9 +444,16 @@ where
         }
     }
 
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
+        bytes byte_buf unit unit_struct newtype_struct seq tuple tuple_struct
+        map struct enum identifier ignored_any
     }
 }


### PR DESCRIPTION
For example:

```rust
pub type Node = clang_ast::Node<Clang>;

#[derive(Deserialize)]
pub struct Clang {
    pub kind: Option<String>,
}
```

Previously this would fail with a message like `invalid type: string "TranslationUnitDecl", expected option`.