### PR TITLE
Manipulate AnyKind only by reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,7 @@ where
             match map.next_key()? {
                 None => {
                     let kind = AnyKind::Kind(Kind::null);
-                    let deserializer = NodeDeserializer::new(kind, &mut inner, map);
+                    let deserializer = NodeDeserializer::new(&kind, &mut inner, map);
                     break T::deserialize(deserializer)?;
                 }
                 Some(FirstField::Id) => {
@@ -499,7 +499,7 @@ where
                 }
                 Some(FirstField::Kind) => {
                     let kind: AnyKind = map.next_value()?;
-                    let deserializer = NodeDeserializer::new(kind, &mut inner, map);
+                    let deserializer = NodeDeserializer::new(&kind, &mut inner, map);
                     break T::deserialize(deserializer)?;
                 }
                 Some(FirstField::Inner) => {


### PR DESCRIPTION
AnyKind is a whopping 40 bytes, because String is already 24 bytes, then Cow\<str\> adds an enum tag on top to arrive at 32 bytes, and AnyKind adds yet another enum tag to 40 bytes.