### PR TITLE
Add `HTMLEnd/StartTagComment`

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -176,6 +176,8 @@ kind! {
     GNUInlineAttr,
     GNUNullExpr,
     GotoStmt,
+    HTMLEndTagComment,
+    HTMLStartTagComment,
     IfStmt,
     ImplicitCastExpr,
     ImplicitValueInitExpr,


### PR DESCRIPTION
Clang (at least 15) will emit these node kinds when it encounters HTML tags (eg. `<b></b>`) in comments.