### PR TITLE
Add `LifetimeBoundAttr`

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -194,6 +194,7 @@ kind! {
     LValueReferenceType,
     LabelStmt,
     LambdaExpr,
+    LifetimeBoundAttr,
     LikelyAttr,
     LinkageSpecDecl,
     MaterializeTemporaryExpr,

--- a/tests/exhaustive.rs
+++ b/tests/exhaustive.rs
@@ -150,6 +150,7 @@ pub enum Clang {
     LValueReferenceType(LValueReferenceType),
     LabelStmt(LabelStmt),
     LambdaExpr(LambdaExpr),
+    LifetimeBoundAttr(LifetimeBoundAttr),
     LikelyAttr(LikelyAttr),
     LinkageSpecDecl(LinkageSpecDecl),
     MaterializeTemporaryExpr(MaterializeTemporaryExpr),
@@ -1929,6 +1930,15 @@ pub struct LambdaExpr {
     pub r#type: Type,
     #[serde(rename = "valueCategory")]
     pub value_category: ValueCategory,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct LifetimeBoundAttr {
+    pub range: SourceRange,
+    #[serde(default)]
+    pub implicit: bool,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This attribute now appears with clang 16 when compiling items like std::move/forward/addressof