### PR TITLE
Speed up interned filepath hashing using fxhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/clang-ast"
 
 [dependencies]
+fxhash = "0.2"
 serde = "1.0.166"
 
 [dev-dependencies]

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,12 +1,12 @@
+use fxhash::FxHashSet as HashSet;
 use serde::de::{DeserializeSeed, Deserializer, Error, Visitor};
 use std::cell::{Cell, RefCell};
-use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
 thread_local! {
     static REFCOUNT: Cell<usize> = Cell::new(0);
-    static INTERN: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::new());
+    static INTERN: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::default());
 }
 
 fn borrowed(string: &str) -> Arc<str> {


### PR DESCRIPTION
Tested using the following benchmark:

```rust
mod intern;
mod loc;

use memmap2::Mmap;
use std::fs::File;
use std::str;

fn main() {
    let mut file = File::open("files.txt").unwrap();
    let mmap = unsafe { Mmap::map(&file) }.unwrap();
    let content = str::from_utf8(&mmap).unwrap();

    for _ in 0..100 {
        for line in content.lines() {
            let _ = intern::borrowed(line);
        }
    }
}
```

where files.txt is all the `"file"` values from the ast.json from our test suite (https://github.com/dtolnay/clang-ast/blob/0.1.19/tests/clone/build.rs). `rg '"file":' | sed 's/^ *"file": "\([^"]*\)",\?$/\1/' > files.txt`

**Before:**&emsp;0m3.818s
**After:**&emsp;0m2.851s

I also tested `seahash` (same performance as default hash) and `ahash` (same performance as fxhash but more dependencies) and BTreeSet (slowest).