### PR TITLE
Replace fxhash with rustc-hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/clang-ast"
 
 [dependencies]
-fxhash = "0.2"
+rustc-hash = "1.1"
 serde = "1.0.166"
 
 [dev-dependencies]

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,4 +1,4 @@
-use fxhash::FxHashSet as HashSet;
+use rustc_hash::FxHashSet as HashSet;
 use serde::de::{DeserializeSeed, Deserializer, Error, Visitor};
 use std::cell::{Cell, RefCell};
 use std::fmt;


### PR DESCRIPTION
This has a less concerning maintenance story, identical performance, and is already a dependency of bindgen.