### PR TITLE
Remove option_if_let_else clippy suppression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,6 @@
     clippy::let_underscore_untyped,
     clippy::match_like_matches_macro,
     clippy::must_use_candidate,
-    clippy::option_if_let_else,
     clippy::ptr_arg,
     clippy::uninlined_format_args
 )]


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.