### PR TITLE
Move public impl blocks out of macro

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -20,27 +20,21 @@ macro_rules! kind {
             null,
         }
 
-        impl Kind {
-            pub fn as_str(&self) -> &'static str {
-                match self {
-                    $(
-                        Kind::$kind => stringify!($kind),
-                    )*
-                    Kind::null => "null",
-                }
+        fn as_str(kind: &Kind) -> &'static str {
+            match kind {
+                $(
+                    Kind::$kind => stringify!($kind),
+                )*
+                Kind::null => "null",
             }
         }
 
-        impl FromStr for Kind {
-            type Err = ParseKindError;
-
-            fn from_str(kind: &str) -> Result<Self, Self::Err> {
-                match kind {
-                    $(
-                        stringify!($kind) => Ok(Kind::$kind),
-                    )*
-                    _other => Err(ParseKindError { _private: () }),
-                }
+        fn from_str(kind: &str) -> Result<Kind, ParseKindError> {
+            match kind {
+                $(
+                    stringify!($kind) => Ok(Kind::$kind),
+                )*
+                _other => Err(ParseKindError { _private: () }),
             }
         }
 
@@ -316,6 +310,20 @@ kind! {
     WeakImportAttr,
     WeakRefAttr,
     WhileStmt,
+}
+
+impl Kind {
+    pub fn as_str(&self) -> &'static str {
+        as_str(self)
+    }
+}
+
+impl FromStr for Kind {
+    type Err = ParseKindError;
+
+    fn from_str(kind: &str) -> Result<Self, Self::Err> {
+        from_str(kind)
+    }
 }
 
 impl Default for Kind {


### PR DESCRIPTION
This makes more useful rustdoc "Source" links and IDE go-to-definition. Previously these would just go to the `kind!` macro invocation:

https://github.com/dtolnay/clang-ast/blob/ad8ece9efaee3e1201443d2df716a0f64b458e21/src/kind.rs#L55

Now they'll go to an actual impl block, and you can click through to the macro-generated implementation function.