### PR TITLE
Add PartialEq<Kind> impls

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -344,6 +344,18 @@ impl Debug for Kind {
     }
 }
 
+impl PartialEq<Kind> for str {
+    fn eq(&self, kind: &Kind) -> bool {
+        self == kind.as_str()
+    }
+}
+
+impl PartialEq<Kind> for String {
+    fn eq(&self, kind: &Kind) -> bool {
+        self == kind.as_str()
+    }
+}
+
 impl<'de> Deserialize<'de> for Kind {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
This is useful for working with untyped nodes.

```rust
use clang_ast::{Kind, Node};

#[derive(Deserialize)]
struct Clang {
    kind: String,
    ...
}

let node: Node<Clang>;

if node.kind == Kind::FullComment {
    ...
}
```

Using PartialEq with the Kind enum rules out typos better than `node.kind == "FullComment"`.